### PR TITLE
[기능 구현] EditBoxModal.js - 선택한 문자열의 위치에 따라서 `EditBoxModal.js`을 띄우기

### DIFF
--- a/src/components/atoms/TextBox.js
+++ b/src/components/atoms/TextBox.js
@@ -1,7 +1,13 @@
 import { useState } from 'react';
 import styled from 'styled-components';
 
-export default function TextBox({ id, index, content, handleContentInput }) {
+export default function TextBox({
+  id,
+  index,
+  content,
+  handleContentInput,
+  setModalState,
+}) {
   const [currentContent, setCurrentContent] = useState(content);
   // const [areaHeight, setAreaHeight] = useState(25);
 
@@ -82,6 +88,26 @@ export default function TextBox({ id, index, content, handleContentInput }) {
         // 아래 글에 따르면, textarea에서는 불가능하다고 함
         // div 태그의 contenteditable 속성을 이용하라고 한다... 구조를 바꿔야 할 듯
         // https://stackoverflow.com/questions/4705848/rendering-html-inside-textarea
+
+        // Getting selected text position (stackoverflow 글)
+        // https://stackoverflow.com/questions/5176761/getting-selected-text-position
+        let { x, y } = range.getBoundingClientRect();
+
+        console.log({ x, y });
+
+        if (selectedText.length > 0) {
+          setModalState({
+            isShow: true,
+            x: x,
+            y: y,
+          });
+        } else {
+          setModalState({
+            isShow: false,
+            x: x,
+            y: y,
+          });
+        }
       }}
       value={currentContent}
     ></TextBoxWrap>

--- a/src/components/molecules/EditBox.js
+++ b/src/components/molecules/EditBox.js
@@ -22,15 +22,16 @@ export default function EditBox({ isShow }) {
   );
 }
 
+// display: ${(props) => (props.isShow ? 'inline' : 'none')};
 const EditBoxWrap = styled.div`
-  display: ${(props) => (props.isShow ? 'inline' : 'none')};
   position: absolute;
-  z-index: 1px;
+  z-index: 5px;
   padding: 5px;
   cursor: pointer;
 
   border: 1px solid black;
   border-radius: 5px;
+  background-color: white;
 `;
 
 const EditBtnBox = styled.div`

--- a/src/components/organisms/EditBoxModal.js
+++ b/src/components/organisms/EditBoxModal.js
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+import { EditBox } from '../molecules';
+
+export default function EditBoxModal({ isShow, setModalState, x, y }) {
+  if (!isShow) {
+    return <></>;
+  } else {
+    return (
+      <ModalWrap
+        className={`ModalWrap`}
+        onClick={(e) => {
+          if (e.target.className.indexOf(`ModalWrap`) !== -1) {
+            console.log(`ModalWrap`);
+          }
+        }}
+      >
+        <ModalEditBox className={`ModalEditBox`} x={x} y={y}>
+          <EditBox />
+        </ModalEditBox>
+      </ModalWrap>
+    );
+  }
+}
+
+const ModalWrap = styled.div``;
+
+const ModalEditBox = styled.div`
+  position: fixed;
+  width: 200px; // 임의로 정한 값임
+  top: ${(props) => `${props.y - 40}px`};
+  left: ${(props) => `${props.x + 5}px`};
+  /* background-color: rgba(0, 0, 0, 0.5); */
+  z-index: 3;
+`;

--- a/src/components/organisms/index.js
+++ b/src/components/organisms/index.js
@@ -1,3 +1,4 @@
 import TitleBox from './TitleBox';
+import EditBoxModal from './EditBoxModal';
 
-export { TitleBox };
+export { TitleBox, EditBoxModal };

--- a/src/components/templates/ContentsArea.js
+++ b/src/components/templates/ContentsArea.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { TextBox } from '../atoms';
+import { EditBoxModal } from '../organisms';
 
 export default function ContentsArea() {
   class EachTextParagraph {
@@ -11,6 +12,12 @@ export default function ContentsArea() {
       this.content = content;
     }
   }
+
+  const [modalState, setModalState] = useState({
+    isShow: false,
+    x: 0,
+    y: 0,
+  });
 
   // 현재 나열된 TextBox들의 목록
   // 기본적으로 TextBox 객체 하나가 들어가 있는 상태여야 하지 않나?
@@ -76,6 +83,7 @@ export default function ContentsArea() {
         index={eachTextBox.index}
         content={eachTextBox.content}
         handleContentInput={handleContentInput}
+        setModalState={setModalState}
       />
     );
   });
@@ -91,22 +99,30 @@ export default function ContentsArea() {
   }, [newTextBoxAdded]);
 
   return (
-    <ContentsAreaWrap
-      className='ContentsAreaWrap'
-      onClick={(e) => {
-        let targetClassName = e.target.className;
-        let TextBoxWrapIndex = targetClassName.indexOf('TextBoxWrap');
+    <>
+      <ContentsAreaWrap
+        className='ContentsAreaWrap'
+        onClick={(e) => {
+          let targetClassName = e.target.className;
+          let TextBoxWrapIndex = targetClassName.indexOf('TextBoxWrap');
 
-        if (TextBoxWrapIndex !== -1) {
-          let TextBoxWrapClassName = targetClassName.slice(TextBoxWrapIndex);
-          document.querySelector(`.${TextBoxWrapClassName}`).focus();
-        } else {
-          handleBlankAreaClick();
-        }
-      }}
-    >
-      {contentsList}
-    </ContentsAreaWrap>
+          if (TextBoxWrapIndex !== -1) {
+            let TextBoxWrapClassName = targetClassName.slice(TextBoxWrapIndex);
+            document.querySelector(`.${TextBoxWrapClassName}`).focus();
+          } else {
+            handleBlankAreaClick();
+          }
+        }}
+      >
+        {contentsList}
+      </ContentsAreaWrap>
+      <EditBoxModal
+        isShow={modalState.isShow}
+        setModalState={modalState.setModalState}
+        x={modalState.x}
+        y={modalState.y}
+      />
+    </>
   );
 }
 


### PR DESCRIPTION
  - 작업내용
    - `EditBoxModal.js` 작성
    - `ContentsArea.js`에서 `modalState` 선언하고, `EditBoxModal.js` 모달을 import함
    - 결과 : 각 TextBox 안의 문자열 중 `선택된 부분`이 존재하면(length), `EditBoxModal.js` 모달을 띄움

  - 수정 필요
    - 마지막의 `TextBox`가 내용을 갖고있지 않다면 추가로 만들지 말아야 하는데, 계속 만들어짐
    - `EditBoxModal.js`의 각 버튼을 클릭했을 때 어떻게 동작하도록 만들지 고민해야 함
    - 지금은 `TextBox.js`의 `onMouseUp`에 모달 등이 걸려있는데, 이 이벤트 함수를 `ContentsArea.js`로 올려야 하는지 고민 필요