### PR TITLE
[수정] ContentsArea.js / TextBox.js - 문자열 수정기능 일부 정리

### DIFF
--- a/src/components/atoms/TextBox.js
+++ b/src/components/atoms/TextBox.js
@@ -7,8 +7,9 @@ export default function TextBox({
   content,
   handleContentInput,
   setModalState,
+  handle_blockedText,
 }) {
-  const [currentContent, setCurrentContent] = useState(content);
+  // const [currentContent, setCurrentContent] = useState(content);
   // const [areaHeight, setAreaHeight] = useState(25);
 
   // 아래와 같은 경고가 뜨는데, 좀 더 찾아보고 수정할 것
@@ -22,94 +23,19 @@ export default function TextBox({
     <TextBoxWrap
       className={`TextBoxWrap_${id}`}
       contentEditable={true}
-      onInput={(e) => setCurrentContent(e.currentTarget.innerText)} // onChange 기능이 없으므로 이걸로 대신함
-      onBlur={() => handleContentInput(id, index, currentContent)}
-      onMouseUp={() => {
-        /*  start, end 위치를 정확히 잡아서 앞뒤 남은것들과 붙여넣는다고 생각해서 작성했던 코드 (그게 아니었던 것 같다)
-          let whole = window.getSelection();
-          if (!whole) return;
-
-          let wholeText = whole.anchorNode.wholeText;
-
-          let selectedText = whole.toString();
-
-          console.log({ currentContent, wholeText, selectedText });
-
-      
-          let selection = window.getSelection();
-
-          let start = selection.anchorOffset;
-          let end = selection.focusOffset;
-
-          if (start > end) {
-            [start, end] = [end, start];
-          }
-
-          console.log({ start, end });
-
-          let before = currentContent.slice(0, start);
-          let after = currentContent.slice(end, currentContent.length);
-
-          console.log({ before, after, currentContent });
-        */
-
-        // 아래와 같이 하면 start, end 이런것들을 잡을 필요가 없어보이는데?
-        // 검색어 : 'how to insert tag in div contenteditable'
-        // 참고한 내용 : https://stackoverflow.com/questions/4823691/insert-an-html-element-in-a-contenteditable-element
-
-        // 브라우저에 따라 getSelection 존재 여부 등이 다를 수 있으므로, userSelection을 선언하고 아래와 같이 처리함
-        let userSelection;
-        if (window.getSelection) {
-          userSelection = window.getSelection();
-        } else if (document.selection) {
-          // should come last; Opera!
-          userSelection = document.selection.createRange();
-        }
-
-        let range = userSelection.getRangeAt(0);
-        let selectedText = userSelection.toString();
-
-        let newElement = document.createElement('span');
-        newElement.innerHTML = selectedText;
-        newElement.style.color = 'blue'; // 이 부분은 버튼(기능)마다 달라야 한다 (추가수정 필요한 부분)
-
-        range.deleteContents(); // 블록 잡은 대상을 지우고
-        range.insertNode(newElement); // 그 위치에 새롭게 만든 'newElement' html엘리먼트를 끼워넣는다
-
-        let decoratedText = document.querySelector(`.TextBoxWrap_${id}`)
-          .innerHTML;
-
-        console.log({ decoratedText });
-        setCurrentContent(decoratedText);
-
-        // ==================================================================
-
-        // textarea 의 내용을 앞뒤로 잘라내고, 그 사이에 '편집된 문자열을 태그로 감싸서' 끼워넣으려 했음
-        // 아래 글에 따르면, textarea에서는 불가능하다고 함
-        // div 태그의 contenteditable 속성을 이용하라고 한다... 구조를 바꿔야 할 듯
-        // https://stackoverflow.com/questions/4705848/rendering-html-inside-textarea
-
-        // Getting selected text position (stackoverflow 글)
-        // https://stackoverflow.com/questions/5176761/getting-selected-text-position
-        let { x, y } = range.getBoundingClientRect();
-
-        console.log({ x, y });
-
-        if (selectedText.length > 0) {
-          setModalState({
-            isShow: true,
-            x: x,
-            y: y,
-          });
-        } else {
-          setModalState({
-            isShow: false,
-            x: x,
-            y: y,
-          });
-        }
+      onInput={(e) => {
+        // onChange 기능이 없으므로 이걸로 대신함
+        // 의문 : '매 글자 입력시마다 이 함수가 작동하므로 굉장히 비효율적이지 않을까?'
+        // 그래서 onBlur로 focus가 빠질때만 작동하도록 하는 것을 고려했었음
+        // 추가 의문 : onBlur를 아래와 같이 innerHTML을 보내도록 수정하니까, onInput/useState가 필요없어진 것 같다...?
+        // => 그래서 일단 주석처리하고, issue로 남김
+        // setCurrentContent(e.currentTarget.innerHTML);
+        // handleContentInput(id, index, e.currentTarget.innerHTML);
       }}
-      value={currentContent}
+      onBlur={(e) => handleContentInput(id, index, e.currentTarget.innerHTML)}
+      onMouseUp={() => {
+        handle_blockedText(id, index);
+      }}
     ></TextBoxWrap>
   );
 }

--- a/src/components/templates/ContentsArea.js
+++ b/src/components/templates/ContentsArea.js
@@ -47,7 +47,7 @@ export default function ContentsArea() {
 
   // 여백이나 패딩을 클릭하면 어떻게 동작할지 결정하는 함수
   const handleBlankAreaClick = (innerText) => {
-    // console.log({ innerText });
+    console.log({ innerText });
     if (innerText.length > 0) {
       let nextId = Math.max.apply(null, textBoxIds) + 1;
 
@@ -75,6 +75,77 @@ export default function ContentsArea() {
     ]);
   };
 
+  // 각 TextBox에서 onMouseUp으로 처리하던 것을, ContentArea에서 통합 처리하도록 변경함
+  const handle_blockedText = (textBoxId, textBoxIndex) => {
+    // 아래와 같이 하면 start, end 이런것들을 잡을 필요가 없어보이는데?
+    // 검색어 : 'how to insert tag in div contenteditable'
+    // 참고한 내용 : https://stackoverflow.com/questions/4823691/insert-an-html-element-in-a-contenteditable-element
+
+    // 브라우저에 따라 getSelection 존재 여부 등이 다를 수 있으므로, userSelection을 선언하고 아래와 같이 처리함
+    let userSelection;
+    if (window.getSelection) {
+      userSelection = window.getSelection();
+    } else if (document.selection) {
+      // should come last; Opera!
+      userSelection = document.selection.createRange();
+    }
+
+    let range = userSelection.getRangeAt(0);
+    let selectedText = userSelection.toString();
+    console.log({ selectedText });
+
+    // 꾸미기를 위한 태그를 span으로 사용해서 그런건지,
+    // div로 나뉜 여러줄을 한번에 수정하면, 여러줄이었던 문장이 한줄로 통합되어 버린다
+    // issue로 남겨두었으며, 추후 수정 필요함 (span이 아닌 다른 태그를 써야 할까?)
+    let newElement = document.createElement('span');
+    newElement.innerHTML = selectedText;
+    newElement.style.color = 'blue'; // 이 부분은 버튼(기능)마다 달라야 한다 (추가수정 필요한 부분)
+
+    if (newElement.innerHTML) {
+      range.deleteContents(); // 블록 잡은 대상을 지우고
+      range.insertNode(newElement); // 그 위치에 새롭게 만든 'newElement' html엘리먼트를 끼워넣는다
+    }
+    let decoratedText = document.querySelector(`.TextBoxWrap_${textBoxId}`)
+      .innerHTML;
+
+    console.log({ decoratedText });
+    let before = textList.slice(0, textBoxIndex);
+    let after = textList.slice(textBoxIndex + 1);
+
+    setTextList([
+      ...before,
+      new EachTextParagraph(textBoxId, 'contents', textBoxIndex, decoratedText),
+      ...after,
+    ]);
+
+    // ==================================================================
+
+    // textarea 의 내용을 앞뒤로 잘라내고, 그 사이에 '편집된 문자열을 태그로 감싸서' 끼워넣으려 했음
+    // 아래 글에 따르면, textarea에서는 불가능하다고 함
+    // div 태그의 contenteditable 속성을 이용하라고 한다... 구조를 바꿔야 할 듯
+    // https://stackoverflow.com/questions/4705848/rendering-html-inside-textarea
+
+    // Getting selected text position (stackoverflow 글)
+    // https://stackoverflow.com/questions/5176761/getting-selected-text-position
+    let { x, y } = range.getBoundingClientRect();
+
+    console.log({ x, y });
+
+    if (selectedText.length > 0) {
+      setModalState({
+        isShow: true,
+        x: x,
+        y: y,
+      });
+    } else {
+      setModalState({
+        isShow: false,
+        x: x,
+        y: y,
+      });
+    }
+  };
+
   // ContentsAreaWrap 안에 나열될 개별 TextBox들의 모임
   let contentsList = textList.map((eachTextBox, index) => {
     return (
@@ -85,6 +156,7 @@ export default function ContentsArea() {
         content={eachTextBox.content}
         handleContentInput={handleContentInput}
         setModalState={setModalState}
+        handle_blockedText={handle_blockedText}
       />
     );
   });
@@ -111,7 +183,10 @@ export default function ContentsArea() {
             let TextBoxWrapClassName = targetClassName.slice(TextBoxWrapIndex);
             document.querySelector(`.${TextBoxWrapClassName}`).focus();
           } else {
-            let childNodes = e.target.childNodes;
+            let nodeContentsAreaWrap = document.querySelector(
+              `.ContentsAreaWrap`
+            );
+            let childNodes = nodeContentsAreaWrap.childNodes;
             let length = childNodes.length;
             let innerText = childNodes[length - 1].innerText;
             handleBlankAreaClick(innerText);


### PR DESCRIPTION
  - 작업내용
    - handle_blockedText : css수정을 위해 각 TextBox에서 onMouseUp으로 처리하던 것을, ContentArea에서 통합 처리하도록 변경하기
    - TextBox.js - onInput / useState로 TextBox.js에서 각 문자열을 직접 관리했는데, 이걸 onBlur 및 handleContentInput(ContentArea.js)에서 한번에 관리하도록 변경하기