### PR TITLE
[기능 구현] 글자 꾸미기를 위한 버튼에 연결할 `decorateText()` 함수 작성

### DIFF
--- a/src/components/atoms/TextEditButton.js
+++ b/src/components/atoms/TextEditButton.js
@@ -1,6 +1,15 @@
+import { useState } from 'react';
 import styled from 'styled-components';
 
-export default function TextEditButton({ type, isDecorated, size }) {
+export default function TextEditButton({
+  type,
+  size,
+  textBoxId,
+  textBoxIndex,
+  decorateText,
+}) {
+  const [isDecorated, setIsDecorated] = useState(false);
+
   let d, stroke;
 
   if (type === 'Bold') {
@@ -26,9 +35,11 @@ export default function TextEditButton({ type, isDecorated, size }) {
   return (
     <TextEditButtonWrap
       className={`${type}ButtonWrap`}
-      onClick={() =>
-        console.log(`상위 컴포넌트의 ${type} 토글기능을 여기다 넣을 것`)
-      }
+      onClick={() => {
+        setIsDecorated(!isDecorated);
+        // console.log(`상위 컴포넌트의 ${type} 토글기능을 여기다 넣을 것`);
+        decorateText(type, !isDecorated, textBoxId, textBoxIndex);
+      }}
     >
       <svg
         viewBox='0 0 15 15'

--- a/src/components/molecules/EditBox.js
+++ b/src/components/molecules/EditBox.js
@@ -2,18 +2,43 @@ import styled from 'styled-components';
 
 import { TextEditButton } from '../atoms';
 
-export default function EditBox({ isShow }) {
+export default function EditBox({ textBoxId, textBoxIndex, decorateText }) {
   return (
-    <EditBoxWrap className='EditBoxWrap' isShow={isShow}>
+    <EditBoxWrap className='EditBoxWrap'>
       <EditBtnBox className='EditBtnBox'>
-        <TextEditButton type='Bold' isDecorated={false} size={20} />
-        <TextEditButton type='Italic' isDecorated={false} size={20} />
-        <TextEditButton type='UnderLine' isDecorated={false} size={20} />
-        <TextEditButton type='StrikeThrough' isDecorated={false} size={20} />
+        <TextEditButton
+          type='Bold'
+          size={20}
+          textBoxId={textBoxId}
+          textBoxIndex={textBoxIndex}
+          decorateText={decorateText}
+        />
+        <TextEditButton
+          type='Italic'
+          size={20}
+          textBoxId={textBoxId}
+          textBoxIndex={textBoxIndex}
+          decorateText={decorateText}
+        />
+        <TextEditButton
+          type='UnderLine'
+          size={20}
+          textBoxId={textBoxId}
+          textBoxIndex={textBoxIndex}
+          decorateText={decorateText}
+        />
+        {/* {'StrikeThrough : textDecoration을 사용해야 하는 점이 UnderLine과 겹쳐서, 일단 주석처리했음'} */}
+        {/* <TextEditButton type='StrikeThrough'  size={20} /> */}
       </EditBtnBox>
 
       <LinkBtnBox className='LinkBtnBox'>
-        <TextEditButton type='Link' isDecorated={false} size={20} />
+        <TextEditButton
+          type='Link'
+          size={20}
+          textBoxId={textBoxId}
+          textBoxIndex={textBoxIndex}
+          decorateText={decorateText}
+        />
         <span style={{ fontSize: '17px', margin: '0px', padding: '0px' }}>
           Link
         </span>
@@ -22,7 +47,6 @@ export default function EditBox({ isShow }) {
   );
 }
 
-// display: ${(props) => (props.isShow ? 'inline' : 'none')};
 const EditBoxWrap = styled.div`
   position: absolute;
   z-index: 5px;

--- a/src/components/organisms/EditBoxModal.js
+++ b/src/components/organisms/EditBoxModal.js
@@ -2,21 +2,26 @@ import { useState } from 'react';
 import styled from 'styled-components';
 import { EditBox } from '../molecules';
 
-export default function EditBoxModal({ isShow, setModalState, x, y }) {
+export default function EditBoxModal({
+  isShow,
+  setModalState,
+  x,
+  y,
+  textBoxId,
+  textBoxIndex,
+  decorateText,
+}) {
   if (!isShow) {
     return <></>;
   } else {
     return (
-      <ModalWrap
-        className={`ModalWrap`}
-        onClick={(e) => {
-          if (e.target.className.indexOf(`ModalWrap`) !== -1) {
-            console.log(`ModalWrap`);
-          }
-        }}
-      >
+      <ModalWrap className={`ModalWrap`}>
         <ModalEditBox className={`ModalEditBox`} x={x} y={y}>
-          <EditBox />
+          <EditBox
+            textBoxId={textBoxId}
+            textBoxIndex={textBoxIndex}
+            decorateText={decorateText}
+          />
         </ModalEditBox>
       </ModalWrap>
     );


### PR DESCRIPTION
  - 작업내용 : `ContentsArea.js` 컴포넌트
    - `decorateText()` 함수 작성 및 각각의 TextEditButton에 내려주기
    - 각 버튼별로 함수를 별도로 선언하지 않고, 위 `decorateText()` 함수에서 type 매개변수에 따라 다르게 동작하도록 처리함
    - 일단 버튼 하나하나는 잘 작동하고 데이터 변경 역시 state에 잘 저장되는 것을 확인했음
    - `handle_blockedText()` 함수는 선택된 부분의 x/y 좌표와 EditBoxModal 토글 여부에만 관여하도록 수정함
    - `getSelectedRange()` 함수를 선언하여, `range` 및 `selectedText`를 받아오는 기능만 별도로 뽑아냈음

  - 문제점 및 개선필요사항
    - 여러 개의 style을 중복 적용하려면 어떻게 해야 할까? : issue #48 남겼음
    - 'StrikeThrough'는 'UnderLine'과 `textDecoration` 속성을 공유하므로, 속성 중복이 예상되어 일단 버튼 자체를 주석처리했음
    - 'Link' 버튼은 어떻게 처리할지 별도 구상이 필요함
    - `ContentsArea.js` 컴포넌트가 지저분하므로 정리 필요