### PR TITLE
[fix] ContentsArea.js - 문자 꾸미는 모달 닫기

### DIFF
--- a/src/components/templates/ContentsArea.js
+++ b/src/components/templates/ContentsArea.js
@@ -63,6 +63,16 @@ export default function ContentsArea() {
       ]);
 
       setNewTextBoxAdded(true);
+    } else {
+      // innerText가 없다면 (선택된 문자열이 없는 상황이라면 : 바깥의 빈 공간을 클릭했다면,)
+      // -> 문자 꾸미기 모달을 닫는다
+      setModalState({
+        isShow: false,
+        x: 0,
+        y: 0,
+        textBoxId: NaN,
+        textBoxIndex: NaN,
+      });
     }
   };
 


### PR DESCRIPTION
  - 기존 문제점 : 다른 문자 입력칸을 (드래그 없이) 단순 클릭했을 때에는 모달이 잘 닫혔으나, 문자 입력칸 바깥을 눌렀을 때에는 닫히지 않는 문제 있었음
  - 작업내용 : `handleBlankAreaClick()` 함수로 받는 innerText가 빈 문자열인 경우에, modalState를 변경하여 문자 꾸미는 모달이 닫히도록 함
  - 추가작업 필요 : 본문 부분에서는 동작하나, title 등 상단 부분을 클릭했을 때는 동작하지 않는 문제 있음